### PR TITLE
Add configuration for where Gruntfile.js is located

### DIFF
--- a/README.md
+++ b/README.md
@@ -107,6 +107,15 @@ So as an example, you can make sure a local version of grunt exists using this:
     // runs "grunt build" as part of your gradle build
     build.dependsOn grunt_build
 
+Configuring the Plugin
+----------------------
+
+You can configure the plugin using the "grunt" extension block, like this:
+
+    grunt {
+        // Set the directory where Gruntfile.js should be found
+        workDir = file("${project.projectDir}")
+    }
 
 Automatically downloading Node
 ------------------------------

--- a/src/main/groovy/com/moowork/gradle/grunt/GruntExtension.groovy
+++ b/src/main/groovy/com/moowork/gradle/grunt/GruntExtension.groovy
@@ -1,0 +1,15 @@
+package com.moowork.gradle.grunt
+
+import org.gradle.api.Project
+
+class GruntExtension
+{
+    final static String NAME = 'grunt'
+
+    def File workDir
+
+    GruntExtension( final Project project )
+    {
+        this.workDir = project.projectDir
+    }
+}

--- a/src/main/groovy/com/moowork/gradle/grunt/GruntInstallTask.groovy
+++ b/src/main/groovy/com/moowork/gradle/grunt/GruntInstallTask.groovy
@@ -14,7 +14,9 @@ class GruntInstallTask
 
         setArgs( ['install', 'grunt-cli', 'grunt'] )
 
-        getOutputs().dir( 'node_modules/grunt' )
-        getOutputs().dir( 'node_modules/grunt-cli' )
+        this.project.afterEvaluate {
+            getOutputs().dir( new File( this.project.node.nodeModulesDir, 'node_modules/grunt' ) )
+            getOutputs().dir( new File( this.project.node.nodeModulesDir, 'node_modules/grunt-cli' ) )
+        }
     }
 }

--- a/src/main/groovy/com/moowork/gradle/grunt/GruntInstallTask.groovy
+++ b/src/main/groovy/com/moowork/gradle/grunt/GruntInstallTask.groovy
@@ -15,6 +15,7 @@ class GruntInstallTask
         setArgs( ['install', 'grunt-cli', 'grunt'] )
 
         this.project.afterEvaluate {
+            setWorkingDir( this.project.node.nodeModulesDir )
             getOutputs().dir( new File( this.project.node.nodeModulesDir, 'node_modules/grunt' ) )
             getOutputs().dir( new File( this.project.node.nodeModulesDir, 'node_modules/grunt-cli' ) )
         }

--- a/src/main/groovy/com/moowork/gradle/grunt/GruntPlugin.groovy
+++ b/src/main/groovy/com/moowork/gradle/grunt/GruntPlugin.groovy
@@ -15,6 +15,8 @@ class GruntPlugin
     {
         project.plugins.apply( NodePlugin.class )
 
+        project.extensions.create( GruntExtension.NAME, GruntExtension, project )
+
         project.extensions.extraProperties.set( 'GruntTask', GruntTask.class )
         project.tasks.create( GRUNT_INSTALL_NAME, GruntInstallTask.class )
 

--- a/src/main/groovy/com/moowork/gradle/grunt/GruntTask.groovy
+++ b/src/main/groovy/com/moowork/gradle/grunt/GruntTask.groovy
@@ -16,13 +16,14 @@ class GruntTask
     @Override
     void exec()
     {
-        def localGrunt = this.project.file( GRUNT_SCRIPT )
+        def localGrunt = this.project.file( new File( this.project.node.nodeModulesDir, GRUNT_SCRIPT ) )
         if ( !localGrunt.isFile() )
         {
             throw new GradleException(
                 "Grunt-CLI not installed in node_modules, please first run 'gradle ${GruntPlugin.GRUNT_INSTALL_NAME}'" )
         }
 
+        setWorkingDir( this.project.grunt.workDir )
         setScript( localGrunt )
         super.exec()
     }


### PR DESCRIPTION
This depends on gradle-node-plugin PR https://github.com/srs/gradle-node-plugin/pull/52

Add new 'grunt' extension with option workDir. By default workDir =
projectDir.